### PR TITLE
Fix Rails 5.2 and 6.x Docker images

### DIFF
--- a/meta_request/Dockerfile-rails-5.2
+++ b/meta_request/Dockerfile-rails-5.2
@@ -3,6 +3,7 @@ FROM ruby:2.6-alpine
 RUN apk add --update --no-cache \
         build-base \
         curl-dev \
+        gcompat \
         git \
         nodejs \
         shared-mime-info \
@@ -15,7 +16,7 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.4.22
 RUN gem install rails -v 5.2.3
 RUN rails new .
 

--- a/meta_request/Dockerfile-rails-6.0
+++ b/meta_request/Dockerfile-rails-6.0
@@ -3,6 +3,7 @@ FROM ruby:2.6-alpine
 RUN apk add --update --no-cache \
         build-base \
         curl-dev \
+        gcompat \
         git \
         nodejs \
         shared-mime-info \
@@ -15,7 +16,7 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.4.22
 RUN gem install rails -v 6.0.6
 RUN rails new .
 

--- a/meta_request/Dockerfile-rails-6.1
+++ b/meta_request/Dockerfile-rails-6.1
@@ -3,6 +3,7 @@ FROM ruby:2.6-alpine
 RUN apk add --update --no-cache \
         build-base \
         curl-dev \
+        gcompat \
         git \
         nodejs \
         shared-mime-info \
@@ -15,7 +16,7 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.4.22
 RUN gem install rails -v 6.1.7
 RUN rails new .
 


### PR DESCRIPTION
There were 2 issues that were breaking the build and tests.

1. Updating Ruby Gems itself without specifying a version causes it to update to the latest version which requires Ruby 3. Instead, we specify the latest version compatible with Ruby 2.6.

Compatibility versions found here:
https://rubygems.org/api/v1/versions/rubygems-update.json

2. The version of Alpine Linux shipping with the Ruby 2.6 image is missing a shared library needed to load nokogiri. Adding `gcompat` corrects this.

More information found here:
https://github.com/github/pages-gem/issues/839