### PR TITLE
Fix the Docker build errors

### DIFF
--- a/meta_request/Dockerfile-rails-5.2
+++ b/meta_request/Dockerfile-rails-5.2
@@ -15,7 +15,8 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.4.22
+RUN bundle config force_ruby_platform true
 RUN gem install rails -v 5.2.3
 RUN rails new .
 

--- a/meta_request/Dockerfile-rails-6.0
+++ b/meta_request/Dockerfile-rails-6.0
@@ -15,7 +15,8 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.4.22
+RUN bundle config force_ruby_platform true
 RUN gem install rails -v 6.0.6
 RUN rails new .
 

--- a/meta_request/Dockerfile-rails-6.1
+++ b/meta_request/Dockerfile-rails-6.1
@@ -15,7 +15,8 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.4.22
+RUN bundle config force_ruby_platform true
 RUN gem install rails -v 6.1.7
 RUN rails new .
 

--- a/meta_request/Dockerfile-rails-7.0
+++ b/meta_request/Dockerfile-rails-7.0
@@ -15,7 +15,8 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem update --system
+RUN gem update --system 3.5.7
+RUN bundle config force_ruby_platform true
 RUN gem install rails -v 7.0.4
 RUN rails new .
 


### PR DESCRIPTION
There were 2 issues that were breaking the build and tests.

1. Updating Ruby Gems itself without specifying a version causes it to update to the latest version which requires Ruby 3. Instead, we specify the latest version compatible with the installed Ruby.

Compatibility versions found here:
https://rubygems.org/api/v1/versions/rubygems-update.json

2. All builds were having issues with missing shared libraries. In the case of the Ruby 2.6 images it was nokogiri and for the Ruby 3.0 image it was sqlite3. A common fix for all the builds was to configure Bundler to consider the platform during dependency resolution.

More information found here:
https://bundler.io/v1.14/whats_new.html
https://github.com/sparklemotion/sqlite3-ruby/issues/434 https://github.com/github/pages-gem/issues/839 - alt. fix for Ruby 2.6