### PR TITLE
Add support for Rails 7.1

### DIFF
--- a/meta_request/Dockerfile-rails-7.1
+++ b/meta_request/Dockerfile-rails-7.1
@@ -1,0 +1,36 @@
+FROM ruby:3.3.0-alpine
+
+RUN apk add --update --no-cache \
+        build-base \
+        curl-dev \
+        git \
+        nodejs \
+        shared-mime-info \
+        sqlite-dev \
+        tzdata \
+        yaml-dev \
+        yarn \
+        zlib-dev
+
+RUN mkdir /app /gem
+WORKDIR /app
+
+RUN gem update --system 3.5.7
+RUN bundle config force_ruby_platform true
+RUN gem install rails -v 7.1.3.2
+RUN rails new .
+
+COPY . /gem
+RUN bundle add meta_request --path /gem
+RUN bundle install
+
+COPY res/routes.rb /app/config/
+COPY res/dummy_controller.rb /app/app/controllers/
+COPY res/dummy /app/app/views/dummy
+COPY res/meta_request_test.rb /app/test/integration/
+
+RUN bundle exec rails db:migrate
+
+ENV PARALLEL_WORKERS 1
+
+CMD ["bin/rake"]

--- a/meta_request/docker-compose.yml
+++ b/meta_request/docker-compose.yml
@@ -21,3 +21,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-rails-7.0
+  test-rails-7.1:
+    build:
+      context: .
+      dockerfile: Dockerfile-rails-7.1

--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.license      = 'MIT'
 
   gem.add_dependency 'rack-contrib', '>= 1.1', '< 3'
-  gem.add_dependency 'railties', '>= 3.0.0', '< 7.1'
+  gem.add_dependency 'railties', '>= 3.0.0', '< 7.2'
   gem.add_development_dependency 'rspec', '~> 3.8.0'
   gem.add_development_dependency 'rubocop', '~> 0.74.0'
 


### PR DESCRIPTION
Supporting Rails 7.1 required updating the gemspec upper version and adding a Docker build to test.